### PR TITLE
Harden systemd unit file

### DIFF
--- a/templates/snowflake-proxy.service.j2
+++ b/templates/snowflake-proxy.service.j2
@@ -7,6 +7,25 @@ Wants=network-online.target
 
 [Service]
 ExecStart=/usr/bin/proxy -capacity {{ clients }}
+User={{ snowflake_user }}
+Group={{ snowflake_user }}
+# https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Sandboxing
+ProtectSystem=strict
+ProtectHome=tmpfs
+PrivateTmp=true
+PrivateDevices=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+NoNewPrivileges=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictSUIDSGID=true
+CapabilityBoundingSet=
+ProtectProc=invisible
+PrivateUsers=true
+ProtectHostname=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Run as a non-root user and use some systemd hardening features. Fixes #6. Still works for me even with the restrictions :)

```
Mar 21 13:27:48 hostname proxy[1433716]: 2022/03/21 12:27:48 In the last 30s, there were 1 connections. Traffic Relayed ↑ 9 KB, ↓ 7 KB.
```
It seems pretty solid to me even if there are still some open points.
```bash
✗ PrivateNetwork=                                             Service has access to the host's network                                0.5
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                   0.3
✗ DeviceAllow=                                                Service has a device ACL with some special devices                      0.1
✗ IPAddressDeny=                                              Service does not define an IP address allow list                        0.2
✗ ProtectHome=                                                Service has access to fake empty home directories                       0.1
✗ ProtectKernelLogs=                                          Service may read from or write to the kernel log ring buffer            0.2
✗ SystemCallArchitectures=                                    Service may execute system calls with all ABIs                          0.2
✗ SystemCallFilter=~@clock                                    Service does not filter system calls                                    0.2
✗ SystemCallFilter=~@debug                                    Service does not filter system calls                                    0.2
✗ SystemCallFilter=~@module                                   Service does not filter system calls                                    0.2
✗ SystemCallFilter=~@mount                                    Service does not filter system calls                                    0.2
✗ SystemCallFilter=~@raw-io                                   Service does not filter system calls                                    0.2
✗ SystemCallFilter=~@reboot                                   Service does not filter system calls                                    0.2
✗ SystemCallFilter=~@swap                                     Service does not filter system calls                                    0.2
✗ SystemCallFilter=~@privileged                               Service does not filter system calls                                    0.2
✗ SystemCallFilter=~@resources                                Service does not filter system calls                                    0.2
✗ RestrictRealtime=                                           Service may acquire realtime scheduling                                 0.1
✗ SystemCallFilter=~@cpu-emulation                            Service does not filter system calls                                    0.1
✗ SystemCallFilter=~@obsolete                                 Service does not filter system calls                                    0.1
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                           0.1
✗ LockPersonality=                                            Service may change ABI personality                                      0.1
✗ MemoryDenyWriteExecute=                                     Service may create writable executable memory mappings                  0.1
✗ RemoveIPC=                                                  Service user may leave SysV IPC objects around                          0.1
✗ UMask=                                                      Files created by service are world-readable by default                  0.1
✗ ProcSubset=                                                 Service has full access to non-process /proc files (/proc subset=)      0.1
→ Overall exposure level for snowflake-proxy.service: 3.2 OK 🙂
```
