### PR TITLE
Fixes SPDX license identifier

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,7 +13,7 @@ galaxy_info:
   # - GPL-3.0-only
   # - Apache-2.0
   # - CC-BY-4.0
-  license: license (BSD, MIT)
+  license: BSD-3-Clause OR MIT
 
   min_ansible_version: 2.1
 
@@ -49,7 +49,7 @@ galaxy_info:
   galaxy_tags:
     - networking
     - tor
-    - anonymity  
+    - anonymity
 
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,


### PR DESCRIPTION
Following the rule on how to mention multiple licenses in SPDX license identifier https://spdx.dev/ids/ .

Also removes extra space in the same file.