### PR TITLE
Use the ansible.builtin.git version parameter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,5 +25,8 @@ snowflake_user: snowflake
 # Update standalone version
 snowflake_update: yes
 
+# Use tags from https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/tags
+snowflake_version: v2.5.1 
+
 # Maximum concurrent clients
 clients: 0

--- a/tasks/arch.yml
+++ b/tasks/arch.yml
@@ -18,6 +18,7 @@
 - name: Clone snowflake repo
   ansible.builtin.git:
     repo: 'https://git.torproject.org/pluggable-transports/snowflake.git'
+    version: "{{ snowflake_version }}"
     dest: /home/{{ snowflake_user }}/repo
     update: "{{ snowflake_update }}"
   register: clone_git

--- a/tasks/debian-bullseye.yml
+++ b/tasks/debian-bullseye.yml
@@ -29,6 +29,7 @@
 - name: Clone snowflake repo
   ansible.builtin.git:
     repo: 'https://git.torproject.org/pluggable-transports/snowflake.git'
+    version: "{{ snowflake_version }}"
     dest: /home/{{ snowflake_user }}/repo
     update: "{{ snowflake_update }}"
   register: clone_git

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -29,6 +29,7 @@
 - name: Clone snowflake repo
   ansible.builtin.git:
     repo: 'https://git.torproject.org/pluggable-transports/snowflake.git'
+    version: "{{ snowflake_version }}"
     dest: /home/{{ snowflake_user }}/repo
     update: "{{ snowflake_update }}"
   register: clone_git

--- a/tasks/fedora.yml
+++ b/tasks/fedora.yml
@@ -18,6 +18,7 @@
 - name: Clone snowflake repo
   ansible.builtin.git:
     repo: 'https://git.torproject.org/pluggable-transports/snowflake.git'
+    version: "{{ snowflake_version }}"
     dest: /home/{{ snowflake_user }}/repo
     update: "{{ snowflake_update }}"
   register: clone_git

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -22,6 +22,7 @@
 - name: Clone snowflake repo
   ansible.builtin.git:
     repo: 'https://git.torproject.org/pluggable-transports/snowflake.git'
+    version: "{{ snowflake_version }}"
     dest: /home/{{ snowflake_user }}/repo
     update: "{{ snowflake_update }}"
   register: clone_git


### PR DESCRIPTION
The current role clones the main branch of the snowflake github repo: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/tree/main

This often has unstable code changes and the most recent commit completely breaks snowflake.

Using stable releases via specifying the tags is a better way of doing it; https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/tags

With this PR I propose specifying a version/tag in the `defaults/main.yml` and using this variable in each clone task.

I've tested this on my wide network of snowflake proxies and it works + resolved the issue I was having with building the binary from the latest commits. For context, the issue was that the binary built and the process started but there would be 0 connections. With the v2.5.1 tag connections start appearing immediately.